### PR TITLE
Clarify Git vs Claude Code worktree terminology in worktree refactor playbook

### DIFF
--- a/blog/worktree-refactor-playbook/index.html
+++ b/blog/worktree-refactor-playbook/index.html
@@ -51,6 +51,14 @@
 <li>Validate logging, metrics, and rollback safety</li>
 </ul>
 <h2 id="use-different-worktrees-by-risk-and-parallelism">Use different worktrees by risk and parallelism</h2>
+<h3 id="git-worktree-vs-claude-code-worktree-clarification">Git worktree vs. Claude Code worktree (clarification)</h3>
+<p>Quick clarification: <strong>git worktree</strong> is the underlying git feature. A <strong>Claude Code worktree</strong> is just a Claude Code session opened in a directory that happens to be a git worktree. There is no separate “Claude worktree” mechanism.</p>
+<ul>
+<li>Git creates and manages worktrees (<code>git worktree add/list/remove</code>)</li>
+<li>Claude Code (or any editor/agent) simply opens a specific worktree folder</li>
+<li>If a tool says it “creates worktrees,” it’s automating git commands, not inventing a new concept</li>
+</ul>
+<p>Keep the model straight: <strong>Git worktrees are the filesystem layout; Claude Code worktrees are the AI sessions you attach to each layout.</strong></p>
 <h3 id="mainline-safe-incremental-refactor-default">A) Mainline-safe incremental refactor (default)</h3>
 <p>Worktree strategy: one branch, small commits.</p>
 <p>Use this when you can keep tests green after each step. Merge or rebase frequently to avoid long-lived drift.</p>

--- a/src/content/blog/worktree-refactor-playbook.md
+++ b/src/content/blog/worktree-refactor-playbook.md
@@ -90,6 +90,16 @@ Key things to know:
 
 **The rule of thumb:** if you're going to switch branches more than twice in an hour, or if you need two versions of the code visible at the same time, use a worktree. If it's a simple feature branch you'll merge and delete, a regular branch is fine.
 
+### Git worktree vs. Claude Code worktree (clarification)
+
+This is where people get tripped up: **git worktree** is a core git feature. **Claude Code "worktree"** isn’t a separate mechanism — it’s just a Claude Code session pointed at a folder that happens to be a git worktree. In other words:
+
+- Git creates and manages worktrees (`git worktree add/list/remove`)
+- Claude Code (or any editor/agent) simply opens a specific worktree directory
+- If a tool says it “creates worktrees,” it’s just automating the git commands for you
+
+So the clean mental model is: **Git worktrees are the filesystem layout; Claude Code worktrees are the AI sessions you attach to each layout.** Keep those separate and the workflow makes sense.
+
 ### The AI coding angle
 
 Here's why this matters specifically for vibe coding: when you have Claude Code or Cursor working in a session, **switching branches kills the context**. The AI was building up understanding of the files in your working directory. If you stash and switch to `main` to check something, then switch back, the AI's mental model might not survive the disruption.


### PR DESCRIPTION
### Motivation
- Clarify a potentially misleading passage that conflated Git's built-in `git worktree` feature with the notion of a "worktree" used by Claude Code sessions so readers understand that Claude Code sessions are simply attached to filesystem worktrees rather than a distinct git mechanism.

### Description
- Added a short clarification paragraph and list to both `src/content/blog/worktree-refactor-playbook.md` and the rendered `blog/worktree-refactor-playbook/index.html` explaining that Git manages worktrees (`git worktree add/list/remove`) and Claude Code (or other editors/agents) simply open a worktree directory as a session.

### Testing
- No automated tests were run because this is a content-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69863564012483219d0068fbf19f3f26)