### PR TITLE
Update About page copy and Vibe Coding section

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -19,12 +19,12 @@ import { SITE_DESCRIPTION, SITE_TITLE, PROFILE_IMAGE } from '../consts';
 				<h1>About Me</h1>
 				
 				<p>
-					Full-Stack Software Developer with 6 years of SDE experience building end-to-end web and mobile applications using React, React Native, Node.js, Python, and FastAPI. Deep hands-on experience with AI/ML pipelines, LLMs, NLP, and vector databases (PGVector, TF-IDF/SVD embeddings, Universal Sentence Encoder). Proven ability to architect cloud infrastructure, lead CI/CD pipelines with Docker and GitHub Actions, and ship production systems autonomously at fast-paced startups. Also 4 years of mobile game design experience from concept to App Store launches.
+					Full-Stack Software Developer with 6 years of SDE experience building end-to-end web and mobile applications using SwiftUI, React, React Native, Node.js, Python, and FastAPI. Deep hands-on experience with AI/ML pipelines, RAG, and vector databases (PGVector, TF-IDF/SVD embeddings). Proven ability to architect mobile apps, cloud infrastructure, and CI/CD pipelines from end to end. Over the years, I have shipped production mobile and web apps at fast-paced startups across the US, Canada, and China, from pre-seed to IPO. Also 4 years of mobile game design experience from concept to App Store launches.
 				</p>
 
-				<h2>Planning &amp; Tooling</h2>
+				<h2>Vibe Coding Workflow</h2>
 				<p>
-					For planning, I currently get the best results from Claude Code + Opus. I use ChatGPT Codex 5.2 primarily for implementation - strong at coding, less reliable than Opus or Gemini 3 for large-context planning. For cost-sensitive daily chores, Cursor Auto Mode is often sufficient.
+					For planning, I currently get the best results from Claude Code + Opus. I use ChatGPT Codex primarily for implementation—strong at coding, less reliable than Opus or Gemini 3 for large-context planning. For cost-sensitive daily chores, Cursor Auto Mode is often sufficient. Please check my <a href="https://zywkloo.github.io/blog/worktree-refactor-playbook/">Playbook with Vibe coding</a>.
 				</p>
 				<h2>Recent Experience</h2>
 				<div class="experience-item">


### PR DESCRIPTION
### Motivation
- Refresh the About Me copy to emphasize mobile development (SwiftUI), RAG/vector DB experience, and production delivery across regions.
- Replace the awkward "Planning & Tooling" heading with a more descriptive "Vibe Coding Workflow" and link to the playbook.

### Description
- Updated the main bio paragraph in `src/pages/about.astro` to add `SwiftUI`, mention `RAG`, focus on mobile apps, and note shipping apps across the US, Canada, and China.
- Renamed the `Planning & Tooling` heading to `Vibe Coding Workflow` and rewrote the paragraph to reference the playbook with an inline link to the playbook URL.
- Minor formatting cleanup to ensure a trailing newline at end of file.

### Testing
- Started the dev server with `npm run dev` and verified the site served the updated page successfully.
- Ran a Playwright script to open `http://127.0.0.1:4321/about` and capture a screenshot which saved to `artifacts/about-page.png`, confirming the content renders as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986498bd5c88321b1e9d182f8c643af)