### PR TITLE
Polish blog index social preview with branded OG image

### DIFF
--- a/public/images/blog-og.svg
+++ b/public/images/blog-og.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <radialGradient id="glow" cx="85%" cy="15%" r="55%">
+      <stop offset="0%" stop-color="#6366f1" stop-opacity="0.35"/>
+      <stop offset="60%" stop-color="#4338ca" stop-opacity="0.12"/>
+      <stop offset="100%" stop-color="#111827" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="accentLine" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#6366f1"/>
+      <stop offset="70%" stop-color="#4338ca"/>
+      <stop offset="100%" stop-color="#4338ca" stop-opacity="0"/>
+    </linearGradient>
+    <filter id="softBlur">
+      <feGaussianBlur stdDeviation="40"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="#0f172a"/>
+
+  <!-- Subtle grid dots -->
+  <pattern id="dots" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
+    <circle cx="1" cy="1" r="1" fill="#1e293b"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#dots)"/>
+
+  <!-- Radial glow overlay -->
+  <rect width="1200" height="630" fill="url(#glow)"/>
+
+  <!-- Decorative circle blur (background accent) -->
+  <circle cx="980" cy="120" r="260" fill="#4338ca" fill-opacity="0.18" filter="url(#softBlur)"/>
+  <circle cx="1100" cy="520" r="180" fill="#6366f1" fill-opacity="0.10" filter="url(#softBlur)"/>
+
+  <!-- Left accent bar -->
+  <rect x="72" y="120" width="4" height="340" rx="2" fill="url(#accentLine)"/>
+
+  <!-- "Blog" badge -->
+  <rect x="96" y="114" width="96" height="36" rx="8" fill="#312e81"/>
+  <rect x="96" y="114" width="96" height="36" rx="8" fill="none" stroke="#6366f1" stroke-width="1" stroke-opacity="0.6"/>
+  <text x="144" y="138" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="15" font-weight="600" fill="#a5b4fc" text-anchor="middle" letter-spacing="0.08em">BLOG</text>
+
+  <!-- Main name -->
+  <text x="96" y="248" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif" font-size="74" font-weight="700" fill="#f1f5f9" letter-spacing="-2">Victor Zhang</text>
+
+  <!-- Accent underline on name -->
+  <rect x="96" y="262" width="480" height="3" rx="1.5" fill="url(#accentLine)"/>
+
+  <!-- Role subtitle -->
+  <text x="96" y="318" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif" font-size="28" font-weight="400" fill="#94a3b8" letter-spacing="0.01em">Mobile &amp; Systems Engineer</text>
+
+  <!-- Description -->
+  <text x="96" y="386" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif" font-size="22" fill="#64748b">Writing about iOS, React Native, device sync,</text>
+  <text x="96" y="418" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif" font-size="22" fill="#64748b">backend systems, and engineering craft.</text>
+
+  <!-- Topic chips -->
+  <rect x="96" y="452" width="88" height="30" rx="15" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+  <text x="140" y="472" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="13" fill="#94a3b8" text-anchor="middle">iOS</text>
+
+  <rect x="196" y="452" width="134" height="30" rx="15" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+  <text x="263" y="472" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="13" fill="#94a3b8" text-anchor="middle">React Native</text>
+
+  <rect x="342" y="452" width="116" height="30" rx="15" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+  <text x="400" y="472" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="13" fill="#94a3b8" text-anchor="middle">Swift / Metal</text>
+
+  <rect x="470" y="452" width="104" height="30" rx="15" fill="#1e293b" stroke="#334155" stroke-width="1"/>
+  <text x="522" y="472" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="13" fill="#94a3b8" text-anchor="middle">AI / Agents</text>
+
+  <!-- Bottom divider -->
+  <line x1="96" y1="520" x2="1104" y2="520" stroke="#1e293b" stroke-width="1"/>
+
+  <!-- URL -->
+  <text x="96" y="556" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="20" fill="#4f46e5" letter-spacing="0.02em">zywkloo.github.io/blog</text>
+
+  <!-- Decorative right side - abstract code lines -->
+  <g opacity="0.07" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="15" fill="#818cf8">
+    <text x="740" y="220">const engineer = {</text>
+    <text x="756" y="248">  focus: "mobile + systems",</text>
+    <text x="756" y="276">  stack: ["iOS", "RN", "Go"],</text>
+    <text x="756" y="304">  writing: true,</text>
+    <text x="740" y="332">};</text>
+  </g>
+</svg>

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -10,11 +10,13 @@ interface Props {
 	title: string;
 	description: string;
 	image?: ImageMetadata;
+	ogImageUrl?: string;
 }
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
-const { title, description, image = FallbackImage } = Astro.props;
+const { title, description, image = FallbackImage, ogImageUrl } = Astro.props;
+const ogImage = ogImageUrl ? new URL(ogImageUrl, Astro.site) : new URL(image.src, Astro.url);
 ---
 
 <!-- Global Metadata -->
@@ -48,11 +50,11 @@ const { title, description, image = FallbackImage } = Astro.props;
 <meta property="og:url" content={Astro.url} />
 <meta property="og:title" content={title} />
 <meta property="og:description" content={description} />
-<meta property="og:image" content={new URL(image.src, Astro.url)} />
+<meta property="og:image" content={ogImage} />
 
 <!-- Twitter -->
 <meta property="twitter:card" content="summary_large_image" />
 <meta property="twitter:url" content={Astro.url} />
 <meta property="twitter:title" content={title} />
 <meta property="twitter:description" content={description} />
-<meta property="twitter:image" content={new URL(image.src, Astro.url)} />
+<meta property="twitter:image" content={ogImage} />

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -5,7 +5,7 @@ import BaseHead from '../../components/BaseHead.astro';
 import Footer from '../../components/Footer.astro';
 import FormattedDate from '../../components/FormattedDate.astro';
 import Header from '../../components/Header.astro';
-import { SITE_DESCRIPTION, SITE_TITLE } from '../../consts';
+import { SITE_DESCRIPTION, SITE_TITLE, SITE_AUTHOR } from '../../consts';
 
 const posts = (await getCollection('blog')).sort(
 	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
@@ -15,7 +15,11 @@ const posts = (await getCollection('blog')).sort(
 <!doctype html>
 <html lang="en">
 	<head>
-		<BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
+		<BaseHead
+			title={`Blog | ${SITE_AUTHOR}`}
+			description={SITE_DESCRIPTION}
+			ogImageUrl="/images/blog-og.svg"
+		/>
 		<style>
 			main {
 				width: 960px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -159,32 +159,44 @@
   dependencies:
     fontkitten "^1.0.0"
 
-"@esbuild/darwin-arm64@0.25.11":
+"@esbuild/linux-x64@0.25.11":
   version "0.25.11"
-  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.11.tgz"
-  integrity sha512-VekY0PBCukppoQrycFxUqkCojnTQhdec0vevUL/EDOCnXd9LKWqD/bHwMPzigIJXPhC59Vd1WFIL57SKs2mg4w==
+  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.11.tgz"
+  integrity sha512-HSFAT4+WYjIhrHxKBwGmOOSpphjYkcswF449j6EjsjbinTZbp8PJtjsVK1XFJStdzXdy/jaddAep2FGY+wyFAQ==
 
-"@esbuild/darwin-arm64@0.27.4":
+"@esbuild/linux-x64@0.27.4":
   version "0.27.4"
-  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz"
-  integrity sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==
+  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz"
+  integrity sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==
 
 "@img/colour@^1.0.0":
   version "1.0.0"
   resolved "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz"
   integrity sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==
 
-"@img/sharp-darwin-arm64@0.34.4":
-  version "0.34.4"
-  resolved "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.4.tgz"
-  integrity sha512-sitdlPzDVyvmINUdJle3TNHl+AG9QcwiAMsXmccqsCOMZNIdW2/7S26w0LyU8euiLVzFBL3dXPwVCq/ODnf2vA==
-  optionalDependencies:
-    "@img/sharp-libvips-darwin-arm64" "1.2.3"
-
-"@img/sharp-libvips-darwin-arm64@1.2.3":
+"@img/sharp-libvips-linux-x64@1.2.3":
   version "1.2.3"
-  resolved "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.3.tgz"
-  integrity sha512-QzWAKo7kpHxbuHqUC28DZ9pIKpSi2ts2OJnoIGI26+HMgq92ZZ4vk8iJd4XsxN+tYfNJxzH6W62X5eTcsBymHw==
+  resolved "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.3.tgz"
+  integrity sha512-3JU7LmR85K6bBiRzSUc/Ff9JBVIFVvq6bomKE0e63UXGeRw2HPVEjoJke1Yx+iU4rL7/7kUjES4dZ/81Qjhyxg==
+
+"@img/sharp-libvips-linuxmusl-x64@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.3.tgz"
+  integrity sha512-U5PUY5jbc45ANM6tSJpsgqmBF/VsL6LnxJmIf11kB7J5DctHgqm0SkuXzVWtIY90GnJxKnC/JT251TDnk1fu/g==
+
+"@img/sharp-linux-x64@0.34.4":
+  version "0.34.4"
+  resolved "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.4.tgz"
+  integrity sha512-ZfGtcp2xS51iG79c6Vhw9CWqQC8l2Ot8dygxoDoIQPTat/Ov3qAa8qpxSrtAEAJW+UjTXc4yxCjNfxm4h6Xm2A==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-x64" "1.2.3"
+
+"@img/sharp-linuxmusl-x64@0.34.4":
+  version "0.34.4"
+  resolved "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.4.tgz"
+  integrity sha512-lU0aA5L8QTlfKjpDCEFOZsTYGn3AEiO6db8W5aQDxj0nQkVrZWmN3ZP9sYKWJdtq3PWPhUNlqehWyXpYDcI9Sg==
+  optionalDependencies:
+    "@img/sharp-libvips-linuxmusl-x64" "1.2.3"
 
 "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
@@ -265,10 +277,15 @@
     estree-walker "^2.0.2"
     picomatch "^4.0.2"
 
-"@rollup/rollup-darwin-arm64@4.52.5":
+"@rollup/rollup-linux-x64-gnu@4.52.5":
   version "4.52.5"
-  resolved "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.5.tgz"
-  integrity sha512-takF3CR71mCAGA+v794QUZ0b6ZSrgJkArC+gUiG6LB6TQty9T0Mqh3m2ImRBOxS2IeYBo4lKWIieSvnEk2OQWA==
+  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.5.tgz"
+  integrity sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==
+
+"@rollup/rollup-linux-x64-musl@4.52.5":
+  version "4.52.5"
+  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.5.tgz"
+  integrity sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==
 
 "@shikijs/core@3.23.0":
   version "3.23.0"
@@ -392,10 +409,15 @@
     source-map-js "^1.2.1"
     tailwindcss "4.1.16"
 
-"@tailwindcss/oxide-darwin-arm64@4.1.16":
+"@tailwindcss/oxide-linux-x64-gnu@4.1.16":
   version "4.1.16"
-  resolved "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.16.tgz"
-  integrity sha512-C3oZy5042v2FOALBZtY0JTDnGNdS6w7DxL/odvSny17ORUnaRKhyTse8xYi3yKGyfnTUOdavRCdmc8QqJYwFKA==
+  resolved "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.16.tgz"
+  integrity sha512-ZGHQxDtFC2/ruo7t99Qo2TTIvOERULPl5l0K1g0oK6b5PGqjYMga+FcY1wIUnrUxY56h28FxybtDEla+ICOyew==
+
+"@tailwindcss/oxide-linux-x64-musl@4.1.16":
+  version "4.1.16"
+  resolved "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.16.tgz"
+  integrity sha512-Oi1tAaa0rcKf1Og9MzKeINZzMLPbhxvm7rno5/zuP1WYmpiG0bEHq4AcRUiG2165/WUzvxkW4XDYCscZWbTLZw==
 
 "@tailwindcss/oxide@4.1.16":
   version "4.1.16"
@@ -1153,11 +1175,6 @@ fontkitten@^1.0.0, fontkitten@^1.0.2:
   dependencies:
     tiny-inflate "^1.0.3"
 
-fsevents@~2.3.2, fsevents@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
 get-east-asian-width@^1.0.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz"
@@ -1478,10 +1495,15 @@ kleur@^3.0.3:
   resolved "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-lightningcss-darwin-arm64@1.30.2:
+lightningcss-linux-x64-gnu@1.30.2:
   version "1.30.2"
-  resolved "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz"
-  integrity sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==
+  resolved "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz"
+  integrity sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==
+
+lightningcss-linux-x64-musl@1.30.2:
+  version "1.30.2"
+  resolved "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz"
+  integrity sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==
 
 lightningcss@^1.21.0, lightningcss@1.30.2:
   version "1.30.2"


### PR DESCRIPTION
## Summary

- Replace the generic Astro "Build the web you want" placeholder with a custom branded SVG OG image for `/blog`
- Extend `BaseHead` with an optional `ogImageUrl?: string` prop for static image overrides
- Update the blog index page title to `"Blog | Victor Zhang"` for cleaner link previews in messaging apps

## Preview image design

The new `public/images/blog-og.svg` (1200×630) features:
- Dark background with subtle indigo glow and dot grid
- "Victor Zhang" name in large white type with accent underline
- "Mobile & Systems Engineer" subtitle
- Topic chips: iOS · React Native · Swift/Metal · AI/Agents
- `zywkloo.github.io/blog` URL at the bottom

## Test plan

- [ ] Share `https://zywkloo.github.io/blog/` link in a messaging app and confirm the new branded image appears instead of the Astro placeholder
- [ ] Verify individual blog post previews are unaffected (still use their `heroImage`)
- [ ] Verify other pages (home, etc.) are unaffected (still use the fallback image)

https://claude.ai/code/session_01Nrc8bFeYH2mSSxgMcedYyc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nrc8bFeYH2mSSxgMcedYyc)_