### PR TITLE
blog: RN Culprit #1 — Fabric view-flattening crash (collapsable={false})

### DIFF
--- a/src/content/blog/rn-culprit-01-fabric-view-flattening.md
+++ b/src/content/blog/rn-culprit-01-fabric-view-flattening.md
@@ -1,0 +1,207 @@
+---
+title: "RN Culprit #1: The Fabric View-Flattening Crash"
+series: "RN Culprit"
+description: "A 100%-reproducible crash in React Native Fabric. The stack points squarely at RN internals. The real culprit is two missing collapsable={false} props on absolute-positioned wrappers."
+pubDate: "Jun 25 2026"
+heroImage: "../../assets/react-native-meteor-hero.svg"
+tags: ["React Native", "Fabric", "iOS", "Crash", "New Architecture", "Debugging"]
+---
+
+## The Crime Scene
+
+The app crashes every single time the user manually disconnects a BLE device. The stack trace offers no mercy:
+
+```
+*** Terminating app due to uncaught exception 'NSInternalInconsistencyException',
+reason: 'RCTComponentViewRegistry: Attempt to recycle a mounted view.'
+
+#11  -[RCTComponentViewRegistry _enqueueComponentViewWithComponentHandle:...]
+       at RCTComponentViewRegistry.mm:114
+#12  -[RCTComponentViewRegistry enqueueComponentViewWithComponentHandle:...]
+       at RCTComponentViewRegistry.mm:69
+#13  RCTPerformMountInstructions
+       at RCTMountingManager.mm:67
+```
+
+Nothing in the trace points to our code. Every frame is deep inside React Native Fabric's mounting machinery. This is the classic shape of a Fabric internal crash — and it is always deterministic. 100% reproducible. Not a race condition. A structural bug.
+
+---
+
+## What Fabric Mount Instructions Are
+
+Fabric's rendering pipeline reconciles the JavaScript shadow tree into a list of typed instructions that the main thread executes sequentially:
+
+| Instruction | What it does |
+|---|---|
+| `Create` | Allocate a new native view |
+| `Insert` | Mount it into a parent, call `addSubview` |
+| `Remove` | Call `removeFromSuperview` on the parent |
+| `Delete` | Recycle it back to the pool |
+| `Update` | Push new props / layout metrics |
+
+The invariant that must hold: **Remove always precedes Delete for the same view.** The assertion at `RCTComponentViewRegistry.mm:114` enforces exactly this:
+
+```objc
+RCTAssert(
+    componentViewDescriptor.view.superview == nil,
+    @"RCTComponentViewRegistry: Attempt to recycle a mounted view."
+);
+```
+
+When `Delete` fires for a view whose `superview` is still non-nil, it means `Remove` either never ran or ran against the wrong parent. The crash is not a timing issue — the instruction list for a single commit is executed atomically on the main thread. The ordering is wrong before it even starts executing.
+
+---
+
+## The Backstory: Why There Were Two Views in the First Place
+
+Before diving into the bug, it helps to understand why the problematic component structure existed at all.
+
+The original header code used a ternary to swap between two native components in the same slot:
+
+```jsx
+// old code — the ternary pattern
+{offlineSyncStatus?.kind === 'downloading'
+  ? <ActivityIndicator color="#FFFFFF" size="small" />
+  : <SearchIcon color="#FFFFFF" size={24} />}
+```
+
+When the download state changes, Fabric must `Delete` the `ActivityIndicator` and `Create` + `Insert` the `SearchIcon` (or vice versa). Two different native component types alternating in the same slot under rapid state updates — that is also a known Fabric trigger for "Attempt to recycle a mounted view."
+
+The fix was correct in principle: **stop conditionally mounting and unmounting native components in the same slot.** Instead, keep both always mounted and toggle visibility via opacity:
+
+```jsx
+// new approach — always mounted, opacity toggle
+<View style={[styles.searchIconLayer, isDownloading && styles.transparent]}
+      collapsable={false}>        {/* ← this is what we'll get to */}
+  <SearchIcon color="#FFFFFF" size={24} />
+</View>
+
+<OfflineDownloadIndicator visible={isDownloading} />
+```
+
+This eliminates the `Delete` / `Create` cycle entirely. The always-mount approach is the right call. But it introduced a new crash for a different reason.
+
+---
+
+## The New Culprit: View Flattening
+
+React Native Fabric applies an optimization called **view flattening** (also called view preallocation or collapsing). When a `View` has no visual properties — no `backgroundColor`, no `borderWidth`, no `opacity` set in style — Fabric marks it as *collapsable* and skips allocating a native `UIView` for it entirely. Its children are promoted and inserted directly into the grandparent's native view.
+
+Both new wrapper views fit this profile exactly:
+
+```jsx
+// searchIconLayer: position absolute, no visual properties
+const styles = StyleSheet.create({
+  searchIconLayer: {
+    position: 'absolute',
+    alignItems: 'center',
+    justifyContent: 'center',
+    // no background, no border, no shadow → collapsable
+  },
+  offlineDownloadIndicator: {
+    position: 'absolute',
+    height: 48,
+    width: 124,
+    // still no visual properties → collapsable
+  },
+});
+```
+
+After flattening, the two trees diverge:
+
+```
+Shadow Tree (Fabric's virtual world)
+  Animated.View
+    └── searchIconLayer          ← shadow node exists, NO native view
+          └── SearchIcon (SVG)
+
+UIKit native hierarchy (the real world)
+  Animated.View
+    └── SearchIcon (SVG)         ← promoted one level up
+```
+
+Fabric's reconciler computes `Remove` instructions using shadow tree parent-child relationships. When a layout commit arrives (BLE disconnect causes a state update that changes the header layout), Fabric generates:
+
+```
+Remove SearchIcon from searchIconLayer
+Delete  SearchIcon
+```
+
+`searchIconLayer` has no native view. The `unmountChildComponentView` call targeting it is a no-op. `SearchIcon` is still physically attached to `Animated.View`. Then `Delete` fires — `view.superview != nil` — assertion fails — crash.
+
+---
+
+## The Fix
+
+Force a native view for every absolute-positioned layout wrapper. `collapsable={false}` prevents Fabric from eliminating the view, keeping the shadow tree and UIKit hierarchy structurally identical:
+
+```jsx
+// OfflineDownloadIndicator root
+<View
+  style={[styles.offlineDownloadIndicator, !visible && styles.transparent]}
+  pointerEvents="none"
+  accessibilityElementsHidden={!visible}
+  importantForAccessibility={visible ? 'auto' : 'no-hide-descendants'}
+  collapsable={false}>   {/* ← forces a real UIView */}
+  ...
+</View>
+
+// searchIconLayer in GlobalHeader
+<View
+  style={[styles.searchIconLayer, isDownloading && styles.transparent]}
+  pointerEvents="none"
+  collapsable={false}>   {/* ← same fix */}
+  <SearchIcon color="#FFFFFF" size={24} />
+</View>
+```
+
+With `collapsable={false}`, the shadow tree matches UIKit exactly:
+
+```
+Shadow Tree == UIKit hierarchy
+  Animated.View
+    ├── searchIconLayer (native UIView backed)
+    │     └── SearchIcon
+    └── OfflineDownloadIndicator (native UIView backed)
+          ├── ActivityIndicator
+          └── View > Text, Text
+```
+
+`Remove` now targets the correct parent. `removeFromSuperview` succeeds. `Delete` sees `superview == nil`. No crash.
+
+---
+
+## The Principle
+
+> **Any `position: 'absolute'` View that serves as a layout-only wrapper — no background, no border, no shadow — inside a component that receives layout commits should carry `collapsable={false}`.**
+
+The cost is one extra `UIView` allocation. The benefit is a crash-proof parent-child mapping in Fabric's mount instruction list.
+
+A broader rule for working with Fabric's rendering layer:
+
+**① Do not swap different native component types in the same slot under rapid state changes.** Use always-mounted components with opacity/style toggling instead. Conditional rendering that alternates between `ActivityIndicator` and `SearchIcon` is exactly the pattern that makes Fabric generate conflicting Delete/Create instruction pairs.
+
+**② Any layout-only wrapper View that is `position: 'absolute'` and visually transparent needs `collapsable={false}`.** Fabric's view flattening is silent — there are no warnings, no diagnostics, no "this view was flattened" log. You discover it when the mount instruction references a phantom parent.
+
+**③ Be extra careful inside `Animated.View` with `useNativeDriver: true`.** The native driver manages its subtree on a separate thread. Absolute-positioned children that Fabric collapses break the strict shadow-to-native mapping that the native driver depends on.
+
+**④ View flattening is a Fabric-specific behavior, not an old-arch concept.** Code patterns that worked safely in the old bridge architecture can produce deterministic crashes in Fabric with no migration warning.
+
+---
+
+## Other Fabric Culprits (to be covered in this series)
+
+This crash is one of a family of Fabric gotchas that share the same root: the shadow tree and the native UIKit hierarchy silently diverge. Here are others on the list:
+
+- **Ternary conditional between different native component types** — the root cause this fix was addressing; deserves its own breakdown of the instruction conflict
+- **`setNativeProps` is silently broken in New Arch** — it bypasses the shadow tree entirely; Fabric's next commit overwrites your manual change with no warning
+- **`display: 'none'` parent with children that receive prop updates** — in some RN versions, child update instructions are still generated for `display: none` subtrees, which can conflict with layout-pass optimizations
+- **`KeyboardAvoidingView` behavior differences** — Fabric's layout timing is synchronous where old arch was async; this changes when `onLayout` fires relative to keyboard events, breaking assumptions baked into KAV implementations
+- **`Modal` + Fabric surface isolation** — Modals render on a separate Fabric surface; refs, accessibility focus, and state you pass through portals can silently lose their native backing
+- **`ScrollView` `onScroll` throttling** — the event pipeline changed; throttle values that felt smooth in old arch now skip frames or fire too aggressively in Fabric depending on the native driver configuration
+
+Each of these follows the same investigative pattern: a crash or visual glitch that the stack trace blames on RN internals, with the actual bug hiding in a component pattern that was safe in old arch but breaks a Fabric invariant.
+
+---
+
+*This is part of the **RN Culprit** series — post-mortems on React Native Fabric bugs where the crash stack tells you nothing and the real culprit is hiding in plain sight.*

--- a/src/content/blog/rn-culprit-02-ternary-native-component-swap.md
+++ b/src/content/blog/rn-culprit-02-ternary-native-component-swap.md
@@ -1,0 +1,151 @@
+---
+title: "RN Culprit #2: Ternary Swap Between Different Native Component Types"
+series: "RN Culprit"
+description: "The same crash signature as #1, but a different culprit. Rapidly alternating between two different native components in the same slot corrupts Fabric's commit pipeline."
+pubDate: "Jun 25 2026"
+heroImage: "../../assets/react-native-meteor-hero.svg"
+tags: ["React Native", "Fabric", "iOS", "Crash", "New Architecture", "Debugging"]
+---
+
+## The Same Crash, a Different Cause
+
+```
+*** Terminating app due to uncaught exception 'NSInternalInconsistencyException',
+reason: 'RCTComponentViewRegistry: Attempt to recycle a mounted view.'
+
+#11  -[RCTComponentViewRegistry _enqueueComponentViewWithComponentHandle:...]
+       at RCTComponentViewRegistry.mm:114
+```
+
+Identical stack to [RN Culprit #1](/blog/rn-culprit-01-fabric-view-flattening). Same assertion. Same `Delete` instruction firing on a view whose `superview` is still non-nil.
+
+Different root cause entirely.
+
+---
+
+## The Pattern
+
+```jsx
+{isDownloading
+  ? <ActivityIndicator color="#FFFFFF" size="small" />  // native component A
+  : <SearchIcon color="#FFFFFF" size={24} />}           // native component B
+```
+
+A ternary in a slot. One branch renders a native `ActivityIndicator` (`UIActivityIndicatorView` under the hood). The other renders an SVG-backed `SearchIcon`. The slot always holds one or the other.
+
+When `isDownloading` changes, Fabric must replace one native component with the other:
+
+```
+Transition: true → false
+
+Remove  ActivityIndicator (tag=5) from parent (tag=3)
+Delete  ActivityIndicator (tag=5)       → recycled to pool
+Create  SearchIcon (tag=6)
+Insert  SearchIcon (tag=6) into parent (tag=3)
+```
+
+A clean four-instruction sequence. Harmless for a single, low-frequency transition.
+
+---
+
+## Why It Breaks Under Rapid Updates
+
+The `isDownloading` state was not just a binary flag. It came from a download progress store that updated on every transferred chunk — potentially dozens of times per second. Each update called `setStatus({kind: 'downloading', bytesDone, bytesTotal})`. Each call triggered a render. React batched some, but not all. Multiple Fabric commits were generated and queued.
+
+Now consider the commit pipeline when state alternates `true → false → true` in rapid succession.
+
+Commit A processes `true → false`: Remove+Delete `ActivityIndicator`, Create+Insert `SearchIcon`.  
+Commit B processes `false → true`: Remove+Delete `SearchIcon`, Create+Insert `ActivityIndicator`.
+
+The two commits are dispatched to the main thread and processed sequentially. Within a single commit the instructions execute in order. But there is a subtlety: Fabric's `RCTMountingManager` tracks an in-flight flag. When a transaction arrives while another is being applied, it sets a follow-up flag and the current transaction is asked to re-check state after finishing.
+
+Under high-frequency updates, the commits pile up faster than the main thread can drain them. The shadow tree snapshots that back each commit can fall out of sync with what is actually attached in UIKit. A `Delete` instruction referencing a tag that has already been recycled and re-inserted by a prior commit fires against a view that is still attached — `superview != nil` — assertion fails.
+
+The component types being *different* is what makes this worse than updating a single component. Same-type updates reuse the native view via `Update` instructions and never touch the recycle pool. Different-type swaps always go through Delete+Create, exercising the pool on every single toggle. Under rapid toggling the pool's in/out cycle races against the commit queue.
+
+---
+
+## The Misread Fix
+
+The obvious instinct is to slow down state updates — throttle the progress callbacks, debounce the store writes. That reduces the crash rate but does not eliminate it. The underlying fragility remains: any commit overlap during a type-swap is potentially unsafe. One slow frame during a download can still trigger it.
+
+A less obvious wrong fix: wrapping the ternary in a `key` prop.
+
+```jsx
+{isDownloading
+  ? <ActivityIndicator key="spinner" color="#FFFFFF" size="small" />
+  : <SearchIcon key="icon" color="#FFFFFF" size={24} />}
+```
+
+Explicit keys force React to always unmount the old component and mount the new one cleanly — but "cleanly" still means Delete+Create going through the recycle pool on every toggle. The crash rate can actually increase because React now bypasses its own reconciler heuristics that might have batched updates.
+
+---
+
+## The Right Fix: Remove the Swap Entirely
+
+The root problem is not the frequency. It is the Delete+Create cycle itself for different native component types. The fix is to eliminate the cycle: keep both components mounted at all times and toggle visibility instead.
+
+```jsx
+{/* always mounted — no Delete/Create cycle on state change */}
+<View
+  style={[styles.searchIconLayer, isDownloading && styles.transparent]}
+  collapsable={false}           {/* see RN Culprit #1 for why this matters */}
+  pointerEvents="none"
+  accessibilityElementsHidden={isDownloading}>
+  <SearchIcon color="#FFFFFF" size={24} />
+</View>
+
+<OfflineDownloadIndicator
+  visible={isDownloading}       {/* opacity toggle, not mount/unmount */}
+  display={downloadDisplay}
+/>
+```
+
+With both components always mounted, state changes produce only `Update` instructions — `updateProps`, `updateLayoutMetrics` — never `Delete` or `Create`. The recycle pool is never touched. The commit pipeline processes the update in a single pass regardless of how fast `isDownloading` toggles.
+
+The `collapsable={false}` props are required on any absolute-positioned layout wrapper with no visual properties. That is the subject of [RN Culprit #1](/blog/rn-culprit-01-fabric-view-flattening) — the crash this fix accidentally introduced before `collapsable={false}` was added.
+
+---
+
+## The Principle
+
+> **In Fabric, never alternate between two different native component types in the same slot under state that can change rapidly. The Delete+Create cycle through the view recycle pool is unsafe under commit queue pressure.**
+
+Corollaries:
+
+**① `{condition ? <NativeA /> : <NativeB />}` is a time bomb if `condition` updates frequently.** It works in testing (one or two slow transitions) and breaks in production (rapid updates driven by network I/O, sensor data, or animation timers).
+
+**② Same-type swaps are safe; different-type swaps are not.** `{condition ? <Text style={a} /> : <Text style={b} />}` is always an `Update`. `{condition ? <ActivityIndicator /> : <SearchIcon />}` is always a Delete+Create. The type is what determines the instruction.
+
+**③ The fix is architectural, not a throttle.** Throttling state updates papers over the crash; eliminating the type-swap prevents it. The two strategies have different failure modes: throttling fails when a frame drops; always-mount never fails at the Fabric level.
+
+**④ Always-mount + opacity requires `collapsable={false}` on layout-only wrappers.** The two fixes are a pair — applying one without the other trades one crash for another. See [RN Culprit #1](/blog/rn-culprit-01-fabric-view-flattening).
+
+---
+
+## Recognising the Pattern in the Wild
+
+Any ternary or `&&` short-circuit that produces a different native component type is a candidate:
+
+```jsx
+{/* risky — ActivityIndicator and Image are different native types */}
+{isLoading ? <ActivityIndicator /> : <Image source={avatar} />}
+
+{/* risky — TextInput and Text are different native types */}
+{isEditing ? <TextInput value={name} /> : <Text>{name}</Text>}
+
+{/* risky inside a list — FlatList and ScrollView are different types */}
+{items.length > 0 ? <FlatList data={items} ... /> : <ScrollView>...</ScrollView>}
+```
+
+The tell is: does a state change cause Fabric to swap the native view type at that position? If yes, and if that state can change more than once per second, the recycle pool is under pressure and the crash is a question of when, not if.
+
+---
+
+## What's Next
+
+The next entry in this series covers `setNativeProps` — a common escape hatch for direct native mutations that silently breaks in New Architecture because it bypasses the shadow tree entirely. Fabric overwrites your manual change on the next render with no warning and no error.
+
+---
+
+*Part of the **RN Culprit** series — post-mortems on React Native Fabric bugs where the crash stack tells you nothing and the real culprit is hiding in plain sight.*


### PR DESCRIPTION
## What this adds

First post in the **RN Culprit** series — a post-mortem on the Fabric `Attempt to recycle a mounted view` crash that appears on BLE disconnect.

**Covers:**
- What Fabric mount instructions are (Create / Insert / Remove / Delete)
- Why the ternary → always-mount refactor was the right direction
- How view flattening silently diverges the shadow tree from the UIKit hierarchy
- Why `position: 'absolute'` with no visual properties = collapsable = wrong Remove parent = crash
- The two-line fix: `collapsable={false}`
- Four generalizable Fabric principles
- Preview list of future RN Culprit topics

## File

`src/content/blog/rn-culprit-01-fabric-view-flattening.md`

## Series

`series: "RN Culprit"` — intended to grow incrementally as more Fabric/New Arch gotchas are documented.