### PR TITLE
docs(blog): rewrite RN culprit 02 and 03 to generalize crash triggers

### DIFF
--- a/src/content/blog/rn-culprit-02-fabric-view-flattening.md
+++ b/src/content/blog/rn-culprit-02-fabric-view-flattening.md
@@ -10,7 +10,7 @@ tldr: 'A detailed post-mortem on a 100%-reproducible Fabric crash caused by miss
 
 ## The Crime Scene
 
-The app crashes every single time the user manually disconnects a BLE device. The stack trace offers no mercy:
+A classic Fabric internal crash looks like this. The stack trace offers no mercy:
 
 ```
 *** Terminating app due to uncaught exception 'NSInternalInconsistencyException',
@@ -24,7 +24,9 @@ reason: 'RCTComponentViewRegistry: Attempt to recycle a mounted view.'
        at RCTMountingManager.mm:67
 ```
 
-Nothing in the trace points to our code. Every frame is deep inside React Native Fabric's mounting machinery. This is the classic shape of a Fabric internal crash — and it is always deterministic. 100% reproducible. Not a race condition. A structural bug.
+Nothing in the trace points to your code. Every frame is deep inside React Native Fabric's mounting machinery. This is the classic shape of a Fabric internal crash — and it is often deterministic. Not a random race condition, but a structural bug.
+
+While there are a few distinct triggers for this exact stack trace (such as legacy interop components failing to detach their views), one of the most common—and sneakiest—culprits is **missing `collapsable={false}` props on absolute-positioned layout wrappers.** Let's break down exactly how that happens using a real-world header layout.
 
 ---
 

--- a/src/content/blog/rn-culprit-03-ternary-native-component-swap.md
+++ b/src/content/blog/rn-culprit-03-ternary-native-component-swap.md
@@ -20,7 +20,7 @@ reason: 'RCTComponentViewRegistry: Attempt to recycle a mounted view.'
 
 Identical stack to [RN Culprit #2](/blog/rn-culprit-02-fabric-view-flattening). Same assertion. Same `Delete` instruction firing on a view whose `superview` is still non-nil.
 
-Different root cause entirely.
+But triggered by a different architectural pattern entirely. While legacy interop components (like old gradient libraries) or view flattening are notorious for causing this assertion, another major culprit that lives purely in your React logic is the ternary native component swap.
 
 ---
 


### PR DESCRIPTION
Smoothly generalizes the crash triggers for the Fabric assertion, acknowledging that multiple patterns (flattening, ternary swaps, legacy interop) can cause it.